### PR TITLE
chore: Add required semantic release extra module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,6 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog@6.0.1
             @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@4.6.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes error in semantic release workflow: https://github.com/equinor/terraform-azurerm-storage/runs/6485604423?check_suite_focus=true