### PR TITLE
ci: Use PAT for semantic release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
             @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@4.6.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
`GITHUB_TOKEN` does not have the required permissions to operate on protected branches. Replace `GITHUB_TOKEN` with Personal Access Token (PAT).

## References:

* https://github.com/cycjimmy/semantic-release-action#basic-usage