### PR TITLE
ci: Remove semantic-release plugins that require PAT token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          persist-credentials: false
 
       - name: Release
         uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: "19.0.2"
           extra_plugins: |
-            @semantic-release/changelog@6.0.1
-            @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@4.6.3
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,20 +18,6 @@
     ],
     [
       "@semantic-release/github"
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogTitle": "# Changelog"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md"
-        ]
-      }
     ]
   ]
 }


### PR DESCRIPTION
Remove semantic-release plugins that require PAT token.

Remove lines that were only relevant due to these plugins.

Ref: https://github.com/cycjimmy/semantic-release-action#basic-usage