### PR TITLE
refactor!: Rename variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 | <a name="input_file_readers"></a> [file\_readers](#input\_file\_readers) | The IDs of the Azure AD objects that should have Reader access to this File Storage. | `list(string)` | `[]` | no |
 | <a name="input_file_retention_policy"></a> [file\_retention\_policy](#input\_file\_retention\_policy) | The number of days that files should be retained. | `number` | `30` | no |
 | <a name="input_file_shares"></a> [file\_shares](#input\_file\_shares) | The names of the File Shared to create in this Storage Account. Only lowercase alphanumeric characters and hyphens are allowed. | `list(string)` | `[]` | no |
+| <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | The public IPs or IP ranges in CIDR format that should be able to access this Storage Account. Only IPv4 addresses are allowed. | `list(string)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Log Analytics Workspace to send diagnostics to. | `string` | n/a | yes |
-| <a name="input_network_ip_rules"></a> [network\_ip\_rules](#input\_network\_ip\_rules) | The public IPs or IP ranges in CIDR format that should be able to access this Storage Account. Only IPv4 addresses are allowed. | `list(string)` | `[]` | no |
 | <a name="input_queue_contributors"></a> [queue\_contributors](#input\_queue\_contributors) | The IDs of the Azure AD objects that should have Contributor access to this Queue Storage. | `list(string)` | `[]` | no |
 | <a name="input_queue_readers"></a> [queue\_readers](#input\_queue\_readers) | The IDs of the Azure AD objects that should have Reader access to this Queue Storage. | `list(string)` | `[]` | no |
 | <a name="input_queues"></a> [queues](#input\_queues) | The names of the Queues to create in this Storage Account. Only lowercase alphanumeric characters and hyphens are allowed. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -40,9 +40,9 @@ resource "azurerm_storage_account" "this" {
   }
 
   network_rules {
-    default_action = length(var.network_ip_rules) == 0 ? "Allow" : "Deny"
+    default_action = length(var.firewall_ip_rules) == 0 ? "Allow" : "Deny"
     bypass         = ["AzureServices"]
-    ip_rules       = var.network_ip_rules
+    ip_rules       = var.firewall_ip_rules
   }
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -38,7 +38,7 @@ module "storage" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  network_ip_rules = [data.http.public_ip.body]
+  firewall_ip_rules = [data.http.public_ip.body]
 
   containers = ["container", "container1", "container-2"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "file_retention_policy" {
   default     = 30
 }
 
-variable "network_ip_rules" {
+variable "firewall_ip_rules" {
   description = "The public IPs or IP ranges in CIDR format that should be able to access this Storage Account. Only IPv4 addresses are allowed."
   type        = list(string)
   default     = []


### PR DESCRIPTION
BREAKING CHANGE: Rename variable 'network_ip_rules' to 'firewall_ip_rules'.

To migrate your project, change all module calls where you use variable 'network_ip_rules' with 'firewall_ip_rules'.
