### PR TITLE
docs(readme): remove redundant provider feature in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ Terraform module which creates an Azure Storage Account.
 
 ```terraform
 provider "azurerm" {
-  # Required unless shared access key is explicitly enabled.
-  storage_use_azuread = true
-
   features {}
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,6 +1,4 @@
 provider "azurerm" {
-  storage_use_azuread = true
-
   features {}
 }
 


### PR DESCRIPTION
Not required because shared access key is enabled by default.