### PR TITLE
ci(release): Remove trigger on branch master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   release:
@@ -18,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: lts/*
       - name: Install dependencies
         run: npm install conventional-changelog-conventionalcommits
       - name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
   "branches": [
-    "main",
-    "master"
+    "main"
   ],
   "plugins": [
     [


### PR DESCRIPTION
Remove trigger on branch master to prevent contributors from creating a branch master and triggering a release.