### PR TITLE
fix: prevent error when environment contains hyphen

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 locals {
-  application_alnum = join("", regexall("[a-z0-9]", lower(var.application)))
+  suffix       = "${var.application}-${var.environment}"
+  suffix_alnum = join("", regexall("[a-z0-9]", lower(local.suffix)))
 
   tags = merge({ application = var.application, environment = var.environment }, var.tags)
 }
 
 resource "azurerm_storage_account" "this" {
-  name                = coalesce(var.account_name, "st${local.application_alnum}${var.environment}")
+  name                = coalesce(var.account_name, "st${local.suffix_alnum}")
   resource_group_name = var.resource_group_name
   location            = var.location
 


### PR DESCRIPTION
[Storage account name can only contain lowercase letters and numbers](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage). This module will fail if no custom storage account name is provided and variable "environment" contains a hyphen.

To prevent this error, concat variables "application" and "environment" in a local variable "suffix", convert this local variable to lowercase letter and numbers, then store the value in another local variable "suffix_alnum". Use this local variable to set the name for the storage account.