### PR TITLE
refactor: add default values for arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,26 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       enabled = false
     }
   }
+
+  metric {
+    category = "Capacity"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "Transaction"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
 }
 
 resource "azurerm_role_assignment" "account_contributor" {

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ resource "azurerm_storage_container" "this" {
   name                  = each.value
   storage_account_name  = azurerm_storage_account.this.name
   container_access_type = "private"
+  metadata              = {}
 }
 
 resource "azurerm_storage_queue" "this" {
@@ -60,6 +61,7 @@ resource "azurerm_storage_queue" "this" {
 
   name                 = each.value
   storage_account_name = azurerm_storage_account.this.name
+  metadata             = {}
 }
 
 resource "azurerm_storage_table" "this" {
@@ -75,6 +77,7 @@ resource "azurerm_storage_share" "this" {
   name                 = each.value
   storage_account_name = azurerm_storage_account.this.name
   quota                = 5120
+  metadata             = {}
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {


### PR DESCRIPTION
Add default values to arguments to prevent Terraform from reporting these as "changed outside of Terraform".