### PR TITLE
feat!: enable point-in-time restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ go test -v -timeout 60m
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 0.1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2.74.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.5.0 |
 
 ## Providers
 
@@ -79,6 +80,7 @@ go test -v -timeout 60m
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 0.1.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 2.74.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.5.0 |
 
 ## Modules
 
@@ -89,6 +91,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azapi_update_resource.this](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_role_assignment.account_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -105,6 +108,7 @@ No modules.
 | [azurerm_storage_queue.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_share.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_share) | resource |
 | [azurerm_storage_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
+| [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@ Terraform module which creates an Azure Storage Account.
 ## Usage
 
 ```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source = "azure/azapi
+    }
+  }
+}
+
 provider "azurerm" {
   features {}
 }
+
+provider "azapi" {}
 
 locals {
   application = "my-app"

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ go test -v -timeout 60m
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 0.1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2.74.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 0.1.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 2.74.0 |
 
 ## Modules
@@ -76,6 +78,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azapi_update_resource.this](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_role_assignment.account_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -100,13 +103,9 @@ No modules.
 | <a name="input_account_contributors"></a> [account\_contributors](#input\_account\_contributors) | The IDs of the Azure AD objects that should have Contributor access to this Storage Account. | `list(string)` | `[]` | no |
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | A custom name for this Storage Account. | `string` | `null` | no |
 | <a name="input_account_replication_type"></a> [account\_replication\_type](#input\_account\_replication\_type) | The type of replication to use for this Storage Account. | `string` | `"LRS"` | no |
-| <a name="input_account_tier"></a> [account\_tier](#input\_account\_tier) | The SKU tier to use for this Storage Account. | `string` | `"Standard"` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
-| <a name="input_blob_change_feed_enabled"></a> [blob\_change\_feed\_enabled](#input\_blob\_change\_feed\_enabled) | Is change feed enabled for this Blob Storage? | `bool` | `false` | no |
 | <a name="input_blob_contributors"></a> [blob\_contributors](#input\_blob\_contributors) | The IDs of the Azure AD objects that should have Contributor access to this Blob Storage. | `list(string)` | `[]` | no |
-| <a name="input_blob_delete_retention_policy"></a> [blob\_delete\_retention\_policy](#input\_blob\_delete\_retention\_policy) | The number of days that blobs and containers should be retained. | `number` | `30` | no |
 | <a name="input_blob_readers"></a> [blob\_readers](#input\_blob\_readers) | The IDs of the Azure AD objects that should have Reader access to this Blob Storage. | `list(string)` | `[]` | no |
-| <a name="input_blob_versioning_enabled"></a> [blob\_versioning\_enabled](#input\_blob\_versioning\_enabled) | Is versioning enabled for this Blob Storage? | `bool` | `false` | no |
 | <a name="input_containers"></a> [containers](#input\_containers) | The names of the Storage Containers to create in this Storage Account. Only lowercase alphanumeric characters and hyphens are allowed. | `list(string)` | `[]` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_file_contributors"></a> [file\_contributors](#input\_file\_contributors) | The IDs of the Azure AD objects that should have Contributor access to this File Storage. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
   # TODO: Write a coment.
   # Ref: https://docs.microsoft.com/en-us/azure/backup/blob-backup-overview#protection
-  blob_delete_days = local.blob_pitr_days + 5
+  blob_retention_days = local.blob_pitr_days + 5
 }
 
 resource "azurerm_storage_account" "this" {
@@ -33,11 +33,11 @@ resource "azurerm_storage_account" "this" {
     change_feed_enabled = true
 
     delete_retention_policy {
-      days = local.blob_delete_days
+      days = local.blob_retention_days
     }
 
     container_delete_retention_policy {
-      days = local.blob_delete_days
+      days = local.blob_retention_days
     }
   }
 
@@ -90,7 +90,7 @@ resource "azurerm_storage_management_policy" "this" {
 
     actions {
       version {
-        delete_after_days_since_creation = local.blob_delete_days
+        delete_after_days_since_creation = local.blob_retention_days
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,30 @@ resource "azapi_update_resource" "this" {
   })
 }
 
+resource "azurerm_storage_management_policy" "this" {
+  storage_account_id = azurerm_storage_account.this.id
+
+  rule {
+    name    = "delete-previous-versions"
+    enabled = true
+
+    filters {
+      blob_types = [
+        "blockBlob",
+        "appendBlob"
+      ]
+
+      prefix_match = []
+    }
+
+    actions {
+      version {
+        delete_after_days_since_creation = 14
+      }
+    }
+  }
+}
+
 resource "azurerm_storage_container" "this" {
   for_each = toset(var.containers)
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,6 +1,16 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "azure/azapi"
+    }
+  }
+}
+
 provider "azurerm" {
   features {}
 }
+
+provider "azapi" {}
 
 locals {
   application = random_id.this.hex

--- a/variables.tf
+++ b/variables.tf
@@ -24,12 +24,6 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "account_tier" {
-  description = "The SKU tier to use for this Storage Account."
-  type        = string
-  default     = "Standard"
-}
-
 variable "account_replication_type" {
   description = "The type of replication to use for this Storage Account."
   type        = string
@@ -46,24 +40,6 @@ variable "shared_access_key_enabled" {
   description = "Is authorization with access key enabled for this Storage Account?"
   type        = bool
   default     = true
-}
-
-variable "blob_versioning_enabled" {
-  description = "Is versioning enabled for this Blob Storage?"
-  type        = bool
-  default     = false
-}
-
-variable "blob_change_feed_enabled" {
-  description = "Is change feed enabled for this Blob Storage?"
-  type        = bool
-  default     = false
-}
-
-variable "blob_delete_retention_policy" {
-  description = "The number of days that blobs and containers should be retained."
-  type        = number
-  default     = 30
 }
 
 variable "file_retention_policy" {

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "azure/azapi"
       version = ">= 0.1.0"
     }
+
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.5.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 2.74.0"
     }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 0.1.0"
+    }
   }
 }


### PR DESCRIPTION
## Description

**BREAKING CHANGE**: Enable point-in-time-restore. To migrate your project, remove any references to input variables `account_tier`, `blob_versioning_enabled`, `blob_change_feed_enabled` and `blob_delete_retention_policy` in all calls to this module. If `account_tier` was set to `Premium`, migration will require recreation of the storage account.

Point-in-time restore requires soft-delete to be enabled. A lifecycle management policy has been added to delete old versions.

Point-in-time restore does not prevent accidental deletion of the storage account itself. A delete-lock has been added to prevent this.

Closes #44
Closes #45
Closes #46

## References:
- https://docs.microsoft.com/en-us/azure/storage/blobs/point-in-time-restore-overview
