### PR TITLE
feat: optional cannot-delete lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ No modules.
 | <a name="input_blob_readers"></a> [blob\_readers](#input\_blob\_readers) | The IDs of the Azure AD objects that should have Reader access to this Blob Storage. | `list(string)` | `[]` | no |
 | <a name="input_blob_version_retention_days"></a> [blob\_version\_retention\_days](#input\_blob\_version\_retention\_days) | The number of days that previous versions of blobs should be retained. | `number` | `7` | no |
 | <a name="input_containers"></a> [containers](#input\_containers) | The names of the Storage Containers to create in this Storage Account. Only lowercase alphanumeric characters and hyphens are allowed. | `list(string)` | `[]` | no |
+| <a name="input_create_delete_lock"></a> [create\_delete\_lock](#input\_create\_delete\_lock) | Create a cannot-delete lock to prevent accidental or malicious deletion of this Storage Account? | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_file_contributors"></a> [file\_contributors](#input\_file\_contributors) | The IDs of the Azure AD objects that should have Contributor access to this File Storage. | `list(string)` | `[]` | no |
 | <a name="input_file_readers"></a> [file\_readers](#input\_file\_readers) | The IDs of the Azure AD objects that should have Reader access to this File Storage. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,32 +64,6 @@ resource "azapi_update_resource" "this" {
   })
 }
 
-# Delete previous blob versions to optimize costs.
-resource "azurerm_storage_management_policy" "this" {
-  storage_account_id = azurerm_storage_account.this.id
-
-  rule {
-    name    = "delete-previous-versions"
-    enabled = true
-
-    filters {
-      blob_types   = ["blockBlob"]
-      prefix_match = []
-    }
-
-    actions {
-      version {
-        delete_after_days_since_creation = var.blob_version_retention_days
-      }
-    }
-  }
-}
-
-resource "azurerm_advanced_threat_protection" "this" {
-  target_resource_id = azurerm_storage_account.this.id
-  enabled            = var.threat_protection_enabled
-}
-
 resource "azurerm_storage_container" "this" {
   for_each = toset(var.containers)
 
@@ -121,6 +95,31 @@ resource "azurerm_storage_share" "this" {
   storage_account_name = azurerm_storage_account.this.name
   quota                = 5120
   metadata             = {}
+}
+
+resource "azurerm_storage_management_policy" "this" {
+  storage_account_id = azurerm_storage_account.this.id
+
+  rule {
+    name    = "delete-previous-versions"
+    enabled = true
+
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = []
+    }
+
+    actions {
+      version {
+        delete_after_days_since_creation = var.blob_version_retention_days
+      }
+    }
+  }
+}
+
+resource "azurerm_advanced_threat_protection" "this" {
+  target_resource_id = azurerm_storage_account.this.id
+  enabled            = var.threat_protection_enabled
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -13,6 +13,8 @@ data "http" "public_ip" {
   url = "https://ifconfig.me"
 }
 
+data "azurerm_client_config" "current" {}
+
 resource "random_id" "this" {
   byte_length = 8
 }
@@ -40,13 +42,16 @@ module "storage" {
 
   firewall_ip_rules = [data.http.public_ip.body]
 
-  containers = ["container", "container1", "container-2"]
-
-  queues = ["queue", "queue1", "queue-2"]
-
-  tables = ["FirstTable", "secondTable", "THIRD"]
-
-  file_shares = ["share", "share1", "share-2"]
+  containers  = ["container1", "container2", "container3"]
+  queues      = ["queue1", "queue2", "queue3"]
+  tables      = ["tableOne", "tableTwo", "tableThree"]
+  file_shares = ["share1", "share2", "share3"]
 
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+
+  account_contributors = [data.azurerm_client_config.current.object_id]
+  blob_contributors    = [data.azurerm_client_config.current.object_id]
+  queue_contributors   = [data.azurerm_client_config.current.object_id]
+  table_contributors   = [data.azurerm_client_config.current.object_id]
+  file_contributors    = [data.azurerm_client_config.current.object_id]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,9 @@ variable "file_readers" {
   type        = list(string)
   default     = []
 }
+
+variable "create_delete_lock" {
+  description = "Create a cannot-delete lock to prevent accidental or malicious deletion of this Storage Account?"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Add variabe to remove cannot-delete lock. Useful in scenarios where you have to destroy resources (e.g., a role assignment), but you are not able to because of the lock. In these scenarios, remove the lock, remove the resource, then re-apply the lock.