### PR TITLE
chore: add source for azapi provider

### DIFF
--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "azure/azapi"
+    }
+  }
+}
+
 provider "azurerm" {
   storage_use_azuread = true
 


### PR DESCRIPTION
Add source for AzAPI provider. This is required for Terraform to download this provider. Without this the fixture/test will not run.