### PR TITLE
feat: optional data protection features

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ No modules.
 | <a name="input_account_replication_type"></a> [account\_replication\_type](#input\_account\_replication\_type) | The type of replication to use for this Storage Account. | `string` | `"RAGRS"` | no |
 | <a name="input_allow_blob_public_access"></a> [allow\_blob\_public\_access](#input\_allow\_blob\_public\_access) | Allow public access to this Blob Storage? | `bool` | `false` | no |
 | <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
+| <a name="input_blob_change_feed_enabled"></a> [blob\_change\_feed\_enabled](#input\_blob\_change\_feed\_enabled) | Is change feed enabled for this Blob Storage? | `bool` | `true` | no |
 | <a name="input_blob_delete_retention_days"></a> [blob\_delete\_retention\_days](#input\_blob\_delete\_retention\_days) | The number of days that deleted blobs and containers should be retained. | `number` | `35` | no |
 | <a name="input_blob_pitr_days"></a> [blob\_pitr\_days](#input\_blob\_pitr\_days) | The number of days in the past to set the maximum point-in-time restore point for containers. Must be less than 'blob\_delete\_retention\_days'. | `number` | `30` | no |
+| <a name="input_blob_pitr_enabled"></a> [blob\_pitr\_enabled](#input\_blob\_pitr\_enabled) | Is point-in-time restore enabled for this Blob Storage? | `bool` | `true` | no |
 | <a name="input_blob_version_retention_days"></a> [blob\_version\_retention\_days](#input\_blob\_version\_retention\_days) | The number of days that previous versions of blobs should be retained. | `number` | `7` | no |
+| <a name="input_blob_versioning_enabled"></a> [blob\_versioning\_enabled](#input\_blob\_versioning\_enabled) | Is versioning enabled for this Blob Storage? | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_file_retention_policy"></a> [file\_retention\_policy](#input\_file\_retention\_policy) | The number of days that files should be retained. | `number` | `30` | no |
 | <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | The public IPs or IP ranges in CIDR format that should be able to access this Storage Account. Only IPv4 addresses are allowed. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,8 @@ resource "azurerm_storage_account" "this" {
   tags = local.tags
 
   blob_properties {
-    versioning_enabled  = true
-    change_feed_enabled = true
+    versioning_enabled  = var.blob_versioning_enabled
+    change_feed_enabled = var.blob_change_feed_enabled
 
     delete_retention_policy {
       days = var.blob_delete_retention_days
@@ -57,7 +57,7 @@ resource "azapi_update_resource" "this" {
   body = jsonencode({
     properties = {
       restorePolicy = {
-        enabled = true
+        enabled = var.blob_pitr_enabled
         days    = var.blob_pitr_days
       }
     }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -32,7 +32,6 @@ resource "azurerm_log_analytics_workspace" "this" {
   name                = "log-${local.application}-${local.environment}"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
-  sku                 = "Free"
 }
 
 module "storage" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,18 @@ variable "allow_blob_public_access" {
   default     = false
 }
 
+variable "blob_versioning_enabled" {
+  description = "Is versioning enabled for this Blob Storage?"
+  type        = bool
+  default     = true
+}
+
+variable "blob_change_feed_enabled" {
+  description = "Is change feed enabled for this Blob Storage?"
+  type        = bool
+  default     = true
+}
+
 variable "blob_version_retention_days" {
   description = "The number of days that previous versions of blobs should be retained."
   type        = number
@@ -58,6 +70,12 @@ variable "blob_delete_retention_days" {
   description = "The number of days that deleted blobs and containers should be retained."
   type        = number
   default     = 35
+}
+
+variable "blob_pitr_enabled" {
+  description = "Is point-in-time restore enabled for this Blob Storage?"
+  type        = bool
+  default     = true
 }
 
 variable "blob_pitr_days" {


### PR DESCRIPTION
Data protection features should be optional. Create new variables for enabling/disabling blob versioning, change feed and point-in-time restore.