### PR TITLE
fix: don't output non-existent attributes

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "account_name" {
 
 output "identity_principal_id" {
   description = "The principal ID of the system-assigned identity of this Storage Account."
-  value       = azurerm_storage_account.this.identity.0.principal_id
+  value       = try(azurerm_storage_account.this.identity[0].principal_id, null)
 }
 
 output "account_tier" {


### PR DESCRIPTION
Module currently throws an error if an identity is not configured.