### PR TITLE
chore: add outputs to cmk example

### DIFF
--- a/examples/cmk/outputs.tf
+++ b/examples/cmk/outputs.tf
@@ -1,1 +1,16 @@
+output "resource_group_name" {
+  description = "The name of this resource group."
+  value       = azurerm_resource_group.this.name
+}
 
+output "storage_account_name" {
+  description = "The name of this Storage account."
+  value       = module.storage.account_name
+}
+
+data "azurerm_subscription" "current" {}
+
+output "subscription_id" {
+  description = "The ID of the current subscription."
+  value       = data.azurerm_subscription.current.subscription_id
+}

--- a/examples/cmk/outputs.tf
+++ b/examples/cmk/outputs.tf
@@ -1,5 +1,5 @@
 output "resource_group_name" {
-  description = "The name of this resource group."
+  description = "The name of the resource group containing the resources."
   value       = azurerm_resource_group.this.name
 }
 


### PR DESCRIPTION
Add the standard outputs which are in the other examples.