### PR TITLE
refactor: rename diagnostic settings

### DIFF
--- a/examples/cmk/main.tf
+++ b/examples/cmk/main.tf
@@ -36,8 +36,6 @@ module "storage" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
-  network_rules_default_action = "Allow"
-
   identity = {
     type = "SystemAssigned"
   }

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "azurerm_advanced_threat_protection" "this" {
 resource "azurerm_monitor_diagnostic_setting" "this" {
   for_each = toset(["blob", "queue", "table", "file"])
 
-  name                           = "${azurerm_storage_account.this.name}-${each.value}-logs"
+  name                           = "audit-logs"
   target_resource_id             = "${azurerm_storage_account.this.id}/${each.value}Services/default"
   log_analytics_workspace_id     = var.log_analytics_workspace_id
   log_analytics_destination_type = var.log_analytics_destination_type


### PR DESCRIPTION
Rename diagnostic settings to `audit-logs` to better represent what logs are being send to log analytics.