### PR TITLE
feat!: remove queue properties logging and metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,42 +105,6 @@ resource "azurerm_storage_account" "this" {
     }
   }
 
-  dynamic "queue_properties" {
-    # Check if queue properties is enabled and supported.
-    for_each = (
-      var.queue_properties != null
-      && !local.is_premium_block_blob_storage
-      && !local.is_premium_data_lake_storage
-      && !local.is_premium_file_storage
-      && !local.is_premium_gpv2_storage
-      && !local.is_standard_blob_storage
-    ) ? [var.queue_properties] : []
-
-    content {
-      logging {
-        delete                = queue_properties.value["logging_delete"]
-        read                  = queue_properties.value["logging_read"]
-        write                 = queue_properties.value["logging_write"]
-        version               = queue_properties.value["logging_version"]
-        retention_policy_days = queue_properties.value["logging_retention_policy_days"]
-      }
-
-      hour_metrics {
-        enabled               = queue_properties.value["hour_metrics_enabled"]
-        include_apis          = queue_properties.value["hour_metrics_include_apis"]
-        version               = queue_properties.value["hour_metrics_version"]
-        retention_policy_days = queue_properties.value["hour_metrics_retention_policy_days"]
-      }
-
-      minute_metrics {
-        enabled               = queue_properties.value["minute_metrics_enabled"]
-        include_apis          = queue_properties.value["minute_metrics_include_apis"]
-        version               = queue_properties.value["minute_metrics_version"]
-        retention_policy_days = queue_properties.value["minute_metrics_retention_policy_days"]
-      }
-    }
-  }
-
   dynamic "identity" {
     for_each = local.identity_type != "" ? [0] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -99,28 +99,6 @@ variable "share_retention_policy_days" {
   default     = 30
 }
 
-variable "queue_properties" {
-  description = "The properties of this Queue Storage."
-
-  type = object({
-    logging_delete                       = optional(bool, true)
-    logging_read                         = optional(bool, true)
-    logging_write                        = optional(bool, true)
-    logging_version                      = optional(string, "1.0")
-    logging_retention_policy_days        = optional(number, 10)
-    hour_metrics_enabled                 = optional(bool, true)
-    hour_metrics_include_apis            = optional(bool, true)
-    hour_metrics_version                 = optional(string, "1.0")
-    hour_metrics_retention_policy_days   = optional(number, 10)
-    minute_metrics_enabled               = optional(bool, true)
-    minute_metrics_include_apis          = optional(bool, true)
-    minute_metrics_version               = optional(string, "1.0")
-    minute_metrics_retention_policy_days = optional(number, 10)
-  })
-
-  default = {}
-}
-
 variable "system_assigned_identity_enabled" {
   description = "Should the system-assigned identity be enabled for this Web App?"
   type        = bool


### PR DESCRIPTION
We use diagnostic settings instead.

Fixes #127