### PR TITLE
chore: use remote module sources in examples

### DIFF
--- a/examples/premium-block-blob-storage/main.tf
+++ b/examples/premium-block-blob-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -30,5 +29,4 @@ module "storage" {
   account_tier             = "Premium"
   account_kind             = "BlockBlobStorage"
   account_replication_type = "LRS"
-  access_tier              = null
 }

--- a/examples/premium-data-lake-storage/main.tf
+++ b/examples/premium-data-lake-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -30,6 +29,5 @@ module "storage" {
   account_tier             = "Premium"
   account_kind             = "BlockBlobStorage"
   account_replication_type = "LRS"
-  access_tier              = null
   is_hns_enabled           = true
 }

--- a/examples/premium-file-storage/main.tf
+++ b/examples/premium-file-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/premium-gpv2-storage/main.tf
+++ b/examples/premium-gpv2-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-blob-storage/main.tf
+++ b/examples/standard-blob-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-data-lake-storage/main.tf
+++ b/examples/standard-data-lake-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-gpv2-storage/main.tf
+++ b/examples/standard-gpv2-storage/main.tf
@@ -18,9 +18,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  # source  = "equinor/storage/azurerm"
-  # version = "12.3.0"
-  source = "../.."
+  source  = "equinor/storage/azurerm"
+  version = "12.4.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name


### PR DESCRIPTION
Examples should use remote sources, as per [standard module structure](https://developer.hashicorp.com/terraform/language/modules/develop/structure).

Forcing a patch release to push this to the registry.

Release-As: 12.4.1