### PR TITLE
feat: add private link access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,15 @@ resource "azurerm_storage_account" "this" {
     bypass                     = !var.network_rules_bypass_azure_services ? [] : ["AzureServices"]
     ip_rules                   = var.network_rules_ip_rules
     virtual_network_subnet_ids = var.network_rules_virtual_network_subnet_ids
+
+    dynamic "private_link_access" {
+      for_each = var.endpoint_resource_id != null ? [1] : []
+
+      content {
+        endpoint_resource_id = var.endpoint_resource_id
+        endpoint_tenant_id   = var.endpoint_tenant_id
+      }
+    }
   }
 
   dynamic "custom_domain" {

--- a/main.tf
+++ b/main.tf
@@ -113,11 +113,11 @@ resource "azurerm_storage_account" "this" {
     virtual_network_subnet_ids = var.network_rules_virtual_network_subnet_ids
 
     dynamic "private_link_access" {
-      for_each = var.endpoint_resource_id != null ? [1] : []
+      for_each = var.private_link_accesses
 
       content {
-        endpoint_resource_id = var.endpoint_resource_id
-        endpoint_tenant_id   = var.endpoint_tenant_id
+        endpoint_resource_id = private_link_access.value.endpoint_resource_id
+        endpoint_tenant_id   = private_link_access.value.endpoint_tenant_id
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -184,16 +184,13 @@ variable "network_rules_ip_rules" {
   }
 }
 
-variable "endpoint_resource_id" {
-  type        = string
-  description = "The ID of the Azure resource that should be allowed access to the target storage account."
-  default     = null
-}
-
-variable "endpoint_tenant_id" {
-  type        = string
-  description = "The tenant id of the resource of the resource access rule to be granted access. Defaults to the current tenant id."
-  default     = null
+variable "private_link_accesses" {
+  description = "A list of private link accesses to configure for this Storage account."
+  type = list(object({
+    endpoint_resource_id = string
+    endpoint_tenant_id   = optional(string)
+  }))
+  default = []
 }
 
 variable "custom_domain" {

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,18 @@ variable "network_rules_ip_rules" {
   }
 }
 
+variable "endpoint_resource_id" {
+  type        = string
+  description = "The ID of the Azure resource that should be allowed access to the target storage account."
+  default     = null
+}
+
+variable "endpoint_tenant_id" {
+  type        = string
+  description = "The tenant id of the resource of the resource access rule to be granted access. Defaults to the current tenant id."
+  default     = null
+}
+
 variable "custom_domain" {
   description = "A custom (sub) domain name of the Storage Account"
 


### PR DESCRIPTION
Added a private_link_access block as optional and will only be created if list of endpoint_resource_ids is specified.