### PR TITLE
feat: default to Entra ID authorization in Azure Portal

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "allow_blob_public_access" {
 variable "default_to_oauth_authentication" {
   description = "Default to Entra ID authorization in the Azure Portal when accessing this Storage account?"
   type        = bool
-  default     = false
+  default     = true
   nullable    = false
 }
 


### PR DESCRIPTION
Default to Entra ID authorization in Azure Portal. There'll still be an option to switch to shared key authorization if needed.

If shared key access is enabled, we should still promote use of Entra ID authorization where possible. For example, even though an application requires shared key authorization, users might still be able to use Entra ID.
