### PR TITLE
fix: examples don't work with Azure provider v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,10 @@ Terraform module which creates an Azure Storage account.
     az login
     ```
 
-1. Set active subscription:
-
-    ```console
-    az account set -s <SUBSCRIPTION_NAME_OR_ID>
-    ```
-
 1. Set environment variables:
 
     ```console
+    export ARM_SUBSCRIPTION_ID=<SUBSCRIPTION_ID>
     export TF_VAR_resource_group_name=<RESOURCE_GROUP_NAME>
     export TF_VAR_location=<LOCATION>
     ```

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Terraform module which creates an Azure Storage account.
 1. Set environment variables:
 
     ```bash
-    export ARM_SUBSCRIPTION_ID=<SUBSCRIPTION_ID>
-    export TF_VAR_resource_group_name=<RESOURCE_GROUP_NAME>
-    export TF_VAR_location=<LOCATION>
+    export ARM_SUBSCRIPTION_ID="<SUBSCRIPTION_ID>"
+    export TF_VAR_resource_group_name="<RESOURCE_GROUP_NAME>"
+    export TF_VAR_location="<LOCATION>"
     ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Terraform module which creates an Azure Storage account.
 
 1. Login to Azure:
 
-    ```console
+    ```bash
     az login
     ```
 
 1. Set environment variables:
 
-    ```console
+    ```bash
     export ARM_SUBSCRIPTION_ID=<SUBSCRIPTION_ID>
     export TF_VAR_resource_group_name=<RESOURCE_GROUP_NAME>
     export TF_VAR_location=<LOCATION>
@@ -41,13 +41,13 @@ Terraform module which creates an Azure Storage account.
 
 1. Initialize working directory:
 
-    ```console
+    ```bash
     terraform init
     ```
 
 1. Execute tests:
 
-    ```console
+    ```bash
     terraform test
     ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ Terraform module which creates an Azure Storage account.
 - File soft-delete retention set to 7 days by default.
 - Audit logs sent to given Log Analytics workspace by default.
 
+## Prerequisites
+
+- Install [Terraform](https://developer.hashicorp.com/terraform/install) **version 1.0 or higher**.
+- Install [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
+
 ## Development
-
-1. Clone this repository:
-
-    ```console
-    git clone https://github.com/equinor/terraform-azurerm-storage.git
-    ```
 
 1. Login to Azure:
 

--- a/examples/premium-block-blob-storage/main.tf
+++ b/examples/premium-block-blob-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/premium-data-lake-storage/main.tf
+++ b/examples/premium-data-lake-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/premium-file-storage/main.tf
+++ b/examples/premium-file-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/premium-gpv2-storage/main.tf
+++ b/examples/premium-gpv2-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-blob-storage/main.tf
+++ b/examples/standard-blob-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-data-lake-storage/main.tf
+++ b/examples/standard-data-lake-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name

--- a/examples/standard-gpv2-storage/main.tf
+++ b/examples/standard-gpv2-storage/main.tf
@@ -18,8 +18,7 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "12.4.0"
+  source = "../.."
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name


### PR DESCRIPTION
- Update README to clarify that subscription ID must be set as an environment variable.
- Update examples to use local path in module source, ensuring the examples always use the latest version of the module that supports the latest version of the Azure provider.