### PR TITLE
feat: prevent destroy as a variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,8 +149,7 @@ resource "azurerm_storage_account" "this" {
   }
 
   lifecycle {
-    # Prevent accidental destroy of Storage account.
-    prevent_destroy = true
+    prevent_destroy = var.prevent_destroy
 
     precondition {
       condition     = var.blob_restore_policy_days < var.blob_delete_retention_policy_days

--- a/variables.tf
+++ b/variables.tf
@@ -310,6 +310,13 @@ variable "custom_domain" {
   nullable = true
 }
 
+variable "prevent_destroy" {
+  description = "Protection to prevent accidental destroy of Storage Account"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
 variable "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics workspace to send diagnostics to."
   type        = string


### PR DESCRIPTION
Suggest to have `prevent_destroy` as a variable, as it sometimes would be nice to be able to destroy storage.

Removed comment since the description is now described in the variables.tf file.