### PR TITLE
feat: disable Defender for Storage (classic) by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -340,7 +340,7 @@ variable "diagnostic_setting_enabled_metric_categories" {
 variable "advanced_threat_protection_enabled" {
   description = "Should Defender for Storage (classic) advanced threat protection be enabled for this Storage account?"
   type        = bool
-  default     = true
+  default     = false
   nullable    = false
 }
 


### PR DESCRIPTION
Move to the new Defender for Storage plan instead: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-storage-classic-migrate