### PR TITLE
fix: argument `metric` for resource `azurerm_monitor_diagnostic_setting` has been deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -204,13 +204,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  dynamic "metric" {
-    for_each = toset(concat(["Capacity", "Transaction"], var.diagnostic_setting_enabled_metric_categories))
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
 
     content {
-      # Azure expects explicit configuration of both enabled and disabled metric categories.
-      category = metric.value
-      enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
+      category = enabled_metric.value
     }
   }
 }

--- a/tests/monitoring.tftest.hcl
+++ b/tests/monitoring.tftest.hcl
@@ -1,0 +1,65 @@
+mock_provider "azurerm" {
+  # Override values that are not known until after the plan is applied.
+  override_during = plan
+
+  override_resource {
+    target = azurerm_storage_account.this
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/Microsoft.Storage/storageAccounts/example-storage"
+    }
+  }
+
+  override_resource {
+    target = azurerm_monitor_diagnostic_setting.this
+    values = {
+      log_analytics_destination_type = null
+    }
+  }
+}
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "monitoring_defaults" {
+  command = plan
+
+  variables {
+    account_name               = run.setup_tests.account_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+  }
+
+  assert {
+    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.name == "audit-logs"])
+    error_message = "Diagnostic setting name should be \"audit-logs\" by default"
+  }
+
+  assert {
+    condition     = alltrue([for key, value in azurerm_monitor_diagnostic_setting.this : value.target_resource_id == "${azurerm_storage_account.this.id}/${key}Services/default"])
+    error_message = "Diagnostic setting should be linked to the Storage account resource"
+  }
+
+  assert {
+    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id])
+    error_message = "Diagnostic setting should be linked to the setup test Log Analytics workspace"
+  }
+
+  assert {
+    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.log_analytics_destination_type == null])
+    error_message = "Diagnostic setting should not have a Log Analytics destination type configured for Storage account"
+  }
+
+  assert {
+    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : length(value.enabled_log) == 3]) && alltrue([for value in azurerm_monitor_diagnostic_setting.this : tolist(value.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"])])
+    error_message = "Diagnostic setting should have \"StorageRead\", \"StorageWrite\" and \"StorageDelete\" log categories enabled by default"
+  }
+
+  assert {
+    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : length(value.enabled_metric) == 0])
+    error_message = "Diagnostic setting should not have any metric categories enabled by default"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 4.0.0"
+      source = "hashicorp/azurerm"
+      # Version 4.31.0 is required to use the "enabled_metric" argument for the "azurerm_monitor_diagnostic_setting" resource.
+      version = ">= 4.31.0"
     }
   }
 }


### PR DESCRIPTION
- Replace argument `metric` with `enabled_metric`.
- Bump minimum allowed Azure provider version. Version 4.31.0 is required to use the `enabled_metric` argument.