### PR TITLE
refactor: create explicit diagnostic setting resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,11 +186,84 @@ resource "azurerm_advanced_threat_protection" "this" {
   enabled            = var.advanced_threat_protection_enabled
 }
 
-resource "azurerm_monitor_diagnostic_setting" "this" {
-  for_each = toset(["blob", "queue", "table", "file"])
-
+resource "azurerm_monitor_diagnostic_setting" "blob" {
   name                       = var.diagnostic_setting_name
-  target_resource_id         = "${azurerm_storage_account.this.id}/${each.value}Services/default"
+  target_resource_id         = "${azurerm_storage_account.this.id}/blobServices/default"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  # Ref: https://registry.terraform.io/providers/hashicorp/azurerm/3.65.0/docs/resources/monitor_diagnostic_setting#log_analytics_destination_type
+  log_analytics_destination_type = null
+
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
+
+    content {
+      category = enabled_metric.value
+    }
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "queue" {
+  name                       = var.diagnostic_setting_name
+  target_resource_id         = "${azurerm_storage_account.this.id}/queueServices/default"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  # Ref: https://registry.terraform.io/providers/hashicorp/azurerm/3.65.0/docs/resources/monitor_diagnostic_setting#log_analytics_destination_type
+  log_analytics_destination_type = null
+
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
+
+    content {
+      category = enabled_metric.value
+    }
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "table" {
+  name                       = var.diagnostic_setting_name
+  target_resource_id         = "${azurerm_storage_account.this.id}/tableServices/default"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  # Ref: https://registry.terraform.io/providers/hashicorp/azurerm/3.65.0/docs/resources/monitor_diagnostic_setting#log_analytics_destination_type
+  log_analytics_destination_type = null
+
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
+
+    content {
+      category = enabled_metric.value
+    }
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "file" {
+  name                       = var.diagnostic_setting_name
+  target_resource_id         = "${azurerm_storage_account.this.id}/fileServices/default"
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
   # Ref: https://registry.terraform.io/providers/hashicorp/azurerm/3.65.0/docs/resources/monitor_diagnostic_setting#log_analytics_destination_type

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = azurerm_monitor_diagnostic_setting.this["blob"]
+  to   = azurerm_monitor_diagnostic_setting.blob
+}
+
+moved {
+  from = azurerm_monitor_diagnostic_setting.this["queue"]
+  to   = azurerm_monitor_diagnostic_setting.queue
+}
+
+moved {
+  from = azurerm_monitor_diagnostic_setting.this["table"]
+  to   = azurerm_monitor_diagnostic_setting.table
+}
+
+moved {
+  from = azurerm_monitor_diagnostic_setting.this["file"]
+  to   = azurerm_monitor_diagnostic_setting.file
+}

--- a/tests/monitoring.tftest.hcl
+++ b/tests/monitoring.tftest.hcl
@@ -10,7 +10,28 @@ mock_provider "azurerm" {
   }
 
   override_resource {
-    target = azurerm_monitor_diagnostic_setting.this
+    target = azurerm_monitor_diagnostic_setting.blob
+    values = {
+      log_analytics_destination_type = null
+    }
+  }
+
+  override_resource {
+    target = azurerm_monitor_diagnostic_setting.queue
+    values = {
+      log_analytics_destination_type = null
+    }
+  }
+
+  override_resource {
+    target = azurerm_monitor_diagnostic_setting.table
+    values = {
+      log_analytics_destination_type = null
+    }
+  }
+
+  override_resource {
+    target = azurerm_monitor_diagnostic_setting.file
     values = {
       log_analytics_destination_type = null
     }
@@ -34,32 +55,62 @@ run "monitoring_defaults" {
   }
 
   assert {
-    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.name == "audit-logs"])
+    condition = alltrue([
+      azurerm_monitor_diagnostic_setting.blob.name == "audit-logs",
+      azurerm_monitor_diagnostic_setting.queue.name == "audit-logs",
+      azurerm_monitor_diagnostic_setting.table.name == "audit-logs",
+      azurerm_monitor_diagnostic_setting.file.name == "audit-logs"
+    ])
     error_message = "Diagnostic setting name should be \"audit-logs\" by default"
   }
 
   assert {
-    condition     = alltrue([for key, value in azurerm_monitor_diagnostic_setting.this : value.target_resource_id == "${azurerm_storage_account.this.id}/${key}Services/default"])
+    condition = alltrue([
+      azurerm_monitor_diagnostic_setting.blob.target_resource_id == "${azurerm_storage_account.this.id}/blobServices/default",
+      azurerm_monitor_diagnostic_setting.queue.target_resource_id == "${azurerm_storage_account.this.id}/queueServices/default",
+      azurerm_monitor_diagnostic_setting.table.target_resource_id == "${azurerm_storage_account.this.id}/tableServices/default",
+      azurerm_monitor_diagnostic_setting.file.target_resource_id == "${azurerm_storage_account.this.id}/fileServices/default"
+    ])
     error_message = "Diagnostic setting should be linked to the Storage account resource"
   }
 
   assert {
-    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id])
+    condition = alltrue([
+      azurerm_monitor_diagnostic_setting.blob.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id,
+      azurerm_monitor_diagnostic_setting.queue.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id,
+      azurerm_monitor_diagnostic_setting.table.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id,
+      azurerm_monitor_diagnostic_setting.file.log_analytics_workspace_id == run.setup_tests.log_analytics_workspace_id
+    ])
     error_message = "Diagnostic setting should be linked to the setup test Log Analytics workspace"
   }
 
   assert {
-    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : value.log_analytics_destination_type == null])
+    condition = alltrue([
+      azurerm_monitor_diagnostic_setting.blob.log_analytics_destination_type == null,
+      azurerm_monitor_diagnostic_setting.queue.log_analytics_destination_type == null,
+      azurerm_monitor_diagnostic_setting.table.log_analytics_destination_type == null,
+      azurerm_monitor_diagnostic_setting.file.log_analytics_destination_type == null
+    ])
     error_message = "Diagnostic setting should not have a Log Analytics destination type configured for Storage account"
   }
 
   assert {
-    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : length(value.enabled_log) == 3]) && alltrue([for value in azurerm_monitor_diagnostic_setting.this : tolist(value.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"])])
+    condition = alltrue([
+      length(azurerm_monitor_diagnostic_setting.blob.enabled_log) == 3 && tolist(azurerm_monitor_diagnostic_setting.blob.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"]),
+      length(azurerm_monitor_diagnostic_setting.queue.enabled_log) == 3 && tolist(azurerm_monitor_diagnostic_setting.queue.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"]),
+      length(azurerm_monitor_diagnostic_setting.table.enabled_log) == 3 && tolist(azurerm_monitor_diagnostic_setting.table.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"]),
+      length(azurerm_monitor_diagnostic_setting.file.enabled_log) == 3 && tolist(azurerm_monitor_diagnostic_setting.file.enabled_log)[*].category == tolist(["StorageDelete", "StorageRead", "StorageWrite"])
+    ])
     error_message = "Diagnostic setting should have \"StorageRead\", \"StorageWrite\" and \"StorageDelete\" log categories enabled by default"
   }
 
   assert {
-    condition     = alltrue([for value in azurerm_monitor_diagnostic_setting.this : length(value.enabled_metric) == 0])
+    condition = alltrue([
+      length(azurerm_monitor_diagnostic_setting.blob.enabled_metric) == 0,
+      length(azurerm_monitor_diagnostic_setting.queue.enabled_metric) == 0,
+      length(azurerm_monitor_diagnostic_setting.table.enabled_metric) == 0,
+      length(azurerm_monitor_diagnostic_setting.file.enabled_metric) == 0
+    ])
     error_message = "Diagnostic setting should not have any metric categories enabled by default"
   }
 }


### PR DESCRIPTION
Currently Terraform Registry lists 1 diagnostic setting to be created by this module. This is misleading, since in reality 4 diagnostic resources are created by a `for_each` loop.

Update this module to explicitly create 4 diagnostic setting resources, which results in Terraform Registry listing 4 diagnostic setting resources to be created.

Release-As: 12.13.2